### PR TITLE
use GitHub actions cache

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -9,15 +9,6 @@ on:
   # allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
-# enable the job to write the dependency metadata
-permissions:
-  contents: write
-
-# enable the vcpkg dependency graph integration
-env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  VCPKG_FEATURE_FLAGS: dependencygraph
-
 jobs:
   build:
     strategy:
@@ -27,21 +18,25 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
 
-    - name: Bootstrap vcpkg
-      run: ${{github.workspace}}/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+    - name: Install dependencies via vcpkg
+      run: vcpkg install catch2 --binarysource="clear;x-gha,readwrite"
 
     - name: Configure with CMake (Linux)
       run: |
         cmake -S ${{github.workspace}} -B build \
-        -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
+        -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/vcpkg/scripts/buildsystems/vcpkg.cmake
       if: matrix.os == 'ubuntu-latest'
 
     - name: Configure with CMake (Windows)
       run: |
-        cmake -S ${{github.workspace}} -B build -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake -S ${{github.workspace}} -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/vcpkg/scripts/buildsystems/vcpkg.cmake
       if: matrix.os == 'windows-latest'
 
     - name: Configure with CMake (macOS)
@@ -49,7 +44,7 @@ jobs:
         export OpenMP_ROOT=$(brew --prefix)/opt/libomp
         run: |
           cmake -S ${{github.workspace}} -B build \
-          -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/vcpkg/scripts/buildsystems/vcpkg.cmake
       if: matrix.os == 'macos-latest'
 
     - name: Build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vcpkg"]
-	path = vcpkg
-	url = https://github.com/microsoft/vcpkg

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,0 @@
-{
-    "name": "cpp-dependency-graph-template",
-    "version-string": "0.0.1",
-    "dependencies": [
-      "catch2"
-    ]
-}


### PR DESCRIPTION
This change removes previous GitHub dependency graph and adds actions cache instead